### PR TITLE
Implement validation for the field.

### DIFF
--- a/versionfield/forms.py
+++ b/versionfield/forms.py
@@ -17,10 +17,34 @@ class VersionField(forms.CharField):
         self.number_bits = number_bits
         return super(VersionField, self).__init__(**kwargs)
 
+    def check_format(self, string):
+        """Check that value contains no more than N decimal numbers."""
+        parts = string.split(".")
+        actual_len = len(parts)
+        allowed_len = len(self.number_bits)
+        if actual_len > allowed_len:
+            raise forms.ValidationError("Version has %(actual)d components; only %(allowed)d components are allowed",
+                    code = 'too_long_version',
+                    params = dict(actual=actual_len, allowed=allowed_len))
+        for i, (part, bits) in enumerate(zip(parts, self.number_bits), 1):
+            if not part.isdigit():
+                raise forms.ValidationError("Version's %(index)d component (%(part)s) is not numeric; only numeric values are allowed",
+                        code = 'not_numeric_version',
+                        params = dict(index=i, part=part))
+            num = int(part)
+            max_allowed = (1 << bits) - 1
+            if num > max_allowed:
+                raise forms.ValidationError("Version's %(index)d component (%(part)s) is too big; maximum allowed value for this component is %(allowed)d",
+                        code = 'version_component_too_big',
+                        params = dict(index=i, part=part, allowed=max_allowed))
+
+
     def to_python(self, value):
         """Verifies that value can be converted to a Version object."""
         if not value:
             return None
+
+        self.check_format(value)
 
         if isinstance(value, six.string_types):
             return Version(value, self.number_bits)
@@ -29,3 +53,4 @@ class VersionField(forms.CharField):
             convert_version_int_to_string(value, self.number_bits),
             self.number_bits
         )
+


### PR DESCRIPTION
The validation method now checks the following:

* If version string has too many components (1.2.3.4.5 with only 3
  components allowed);
* If any component is not numeric (1.x is not supported due to storage
  implementation);
* If any component is too big (one can't save number greater than 255
  with 8 bits, for example).

Raising ValidationError in validate() allows us to avoid ValueError
later.